### PR TITLE
fixed how to link

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,6 +17,7 @@
             <h1 class="display-4"><img src="./praatbox_logo.svg" class="mx-auto d-block bb-logo" alt="Praatbox">
             </h1>
             <p id="intro">Met Praatbox kan je videobellen met iemand waar je geen fysiek contact mee mag hebben.</p>
+
           <div class="collapse hide-for-old-visitors" id="uitleg">
             <h2>Hoe gebruik je de Praatbox?</h2>
             <ol class="steps">
@@ -43,7 +44,7 @@
 
       <div class="row my-md-1">
         <div class="col-lg-8 mx-auto d-flex justify-content-between">
-          <p><a href="#uitleg" data-toggle="collapse">Hoe gebruik je de Praatbox?</a></p>
+          <p><a href="#uitleg" data-toggle="collapse" data-target="#uitleg">Hoe gebruik je de Praatbox?</a></p>
           <p><a href="/vragen.html">veelgestelde vragen</a></p>          
         </div>               
       </div>   

--- a/_site/app.js
+++ b/_site/app.js
@@ -100,8 +100,9 @@ $(document).ready(function () {
 
 
 	// Tonen of verbergen uitleg hoe praatbox gebruiken.
-	if (document.cookie.indexOf('_ga') >= 0 ) {
-		$('.hide-for-old-visitors').addClass('hidden');
+	if (document.cookie.indexOf('_ga') < 0 ) {
+        $('.hide-for-old-visitors').removeClass('collapse');
+        $('.hide-for-old-visitors').addClass('collapse-show');
 	}
 
 });

--- a/_site/index.html
+++ b/_site/index.html
@@ -50,6 +50,7 @@
             <h1 class="display-4"><img src="./praatbox_logo.svg" class="mx-auto d-block bb-logo" alt="Praatbox">
             </h1>
             <p id="intro">Met Praatbox kan je videobellen met iemand waar je geen fysiek contact mee mag hebben.</p>
+
           <div class="collapse hide-for-old-visitors" id="uitleg">
             <h2>Hoe gebruik je de Praatbox?</h2>
             <ol class="steps">
@@ -76,7 +77,7 @@
 
       <div class="row my-md-1">
         <div class="col-lg-8 mx-auto d-flex justify-content-between">
-          <p><a href="#uitleg" data-toggle="collapse">Hoe gebruik je de Praatbox?</a></p>
+          <p><a href="#uitleg" data-toggle="collapse" data-target="#uitleg">Hoe gebruik je de Praatbox?</a></p>
           <p><a href="/vragen.html">veelgestelde vragen</a></p>          
         </div>               
       </div>   

--- a/app.js
+++ b/app.js
@@ -102,8 +102,9 @@ $(document).ready(function () {
 
 
 	// Tonen of verbergen uitleg hoe praatbox gebruiken.
-	if (document.cookie.indexOf('_ga') >= 0 ) {
-		$('.hide-for-old-visitors').addClass('hidden');
+	if (document.cookie.indexOf('_ga') < 0 ) {
+        $('.hide-for-old-visitors').removeClass('collapse');
+        $('.hide-for-old-visitors').addClass('collapse-show');
 	}
 
 });


### PR DESCRIPTION
Fix voor https://github.com/MakeInBelgium/babbelbox/issues/64. Dit zorgt ervoor dat de "Hoe gebruik je de Praatbox?" link weer werkt. De functionaliteit om de uitleg niet te tonen aan terugkerende bezoekers is behouden. De uitleg wordt wel getoond wanneer er geen cookie is, ik vermoed dat dit de bedoeling was.